### PR TITLE
fix for win

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "demo for react-redux with graphql and hot",
   "main": "src",
   "scripts": {
-    "start": "concurrently --kill-others 'nodemon api/index.js --watch api --exec ./node_modules/.bin/babel-node' 'nodemon --watch src src' 'node webpack/webpack-dev-server.js'",
+    "start": "concurrently --kill-others \"nodemon api/index.js --watch api --exec babel-node\" \"nodemon --watch src src\" \"node webpack/webpack-dev-server.js\"",
     "prebuild": "rimraf dist",
     "build": "./node_modules/.bin/cross-env NODE_ENV=production webpack -p --optimize-dedupe --config webpack/webpack.config.js",
     "eslint": "eslint ."

--- a/src/server.js
+++ b/src/server.js
@@ -22,7 +22,7 @@ import Html from './components/Html';
 dotenv.config();
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
-const IP = process.env.IP || '0.0.0.0';
+const IP = process.env.IP || 'localhost';
 const PORT = process.env.PORT || 3000;
 const API_URL = process.env.API_URL || 'http://localhost:8081';
 

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -2,7 +2,7 @@ var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');
 
-var IP = process.env.IP || '0.0.0.0';
+var IP = process.env.IP || 'localhost';
 var PORT = (+process.env.PORT + 1) || 3001;
 
 new WebpackDevServer(webpack(config), {

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -4,7 +4,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
 var webpackIsomorphicToolsConfig = require('./webpack-isomorphic-tools');
 
-var IP = process.env.IP || '0.0.0.0';
+var IP = process.env.IP || 'localhost';
 var PORT = (+process.env.PORT + 1) || 3001;
 var WS_PORT = (+process.env.WS_PORT) || 8082;
 var DEBUG = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
I had to update a few things to get this to run on my Windows machine. First, I had to update the `package.json` to run concurrent commands with [escaped double quotes instead of single quotes](https://www.npmjs.com/package/concurrently) to fix errors I was running into. Next, in my build `babel-node` doesn't actually reside in `./node_modules/.bin`, but rather in `./node_modules/babel-cli/.bin` so I changed the reference to skip these paths. Finally, even though the app started fine, I was getting errors in the browser looking for `bundle.js` at `0.0.0.0` causing certain portions of the app not to work correctly--changing `0.0.0.0` to `localhost` in a couple places seemed to resolve it.

Thanks for the repo!